### PR TITLE
feat: support mixed mode & updates

### DIFF
--- a/demos/static-equinix/auto-script.sh
+++ b/demos/static-equinix/auto-script.sh
@@ -30,8 +30,8 @@ pe "clear"
 # slide 5
 pe "export CLUSTER_NAME=mvm-test"
 pe "export CONTROL_PLANE_MACHINE_COUNT=1"
-pe "export WORKER_MACHINE_COUNT=10"
-pe "export CONTROL_PLANE_VIP=192.168.1.25"
+pe "export WORKER_MACHINE_COUNT=5"
+pe "export CONTROL_PLANE_VIP=192.168.10.25"
 pe "clusterctl generate cluster -i microvm:$CAPMVM_VERSION -f cilium $CLUSTER_NAME > cluster.yaml"
 
 # slide 6

--- a/demos/static-equinix/slides.md
+++ b/demos/static-equinix/slides.md
@@ -158,7 +158,7 @@ export WORKER_MACHINE_COUNT=5
   - Here a private address from my Equinix host's VLAN.
 
 ```bash
-export CONTROL_PLANE_VIP="192.168.1.25"
+export CONTROL_PLANE_VIP="192.168.10.25"
 ```
 
 - Use `clusterctl` to generate a manifest definition for the microvm cluster
@@ -189,7 +189,7 @@ metadata:
   namespace: default
 spec:
   controlPlaneEndpoint:
-    host: 192.168.1.25
+    host: 192.168.10.25
     port: 6443
   placement:
     staticPool:

--- a/docs/create.md
+++ b/docs/create.md
@@ -10,11 +10,12 @@ and run: mdtoc -inplace docs/create.md
 -->
 
 <!-- toc -->
-- [Configuration](#configuration)
-- [Create](#create)
-- [Use your new cluster](#use-your-new-cluster)
-- [Delete](#delete)
-- [Troubleshooting](#troubleshooting)
+- [Creating Liquid Metal clusters](#creating-liquid-metal-clusters)
+  - [Configuration](#configuration)
+  - [Create](#create)
+  - [Use your new cluster](#use-your-new-cluster)
+  - [Delete](#delete)
+  - [Troubleshooting](#troubleshooting)
 <!-- /toc -->
 
 ## Configuration
@@ -27,8 +28,8 @@ export WORKER_MACHINE_COUNT=1
 ```
 
 Select an IP from your VLAN IP block range to use for the control plane address.
-(For example, I am using a `192.168.1.0/25` CIDR and have set aside `192.168.1.26`
-to `192.168.1.126` for my MicroVMs, so I can set `192.168.1.25` as my cluster
+(For example, I am using a `192.168.10.0/25` CIDR and have set aside `192.168.10.26`
+to `192.168.10.126` for my MicroVMs, so I can set `192.168.10.25` as my cluster
 endpoint address. This is a naive configuration for the purposes of this demonstration.):
 ```sh
 export CONTROL_PLANE_VIP=<ADDRESS>

--- a/docs/dhcp.md
+++ b/docs/dhcp.md
@@ -45,9 +45,9 @@ default-lease-time 600;
 max-lease-time 7200;
 authoritative;
 
-subnet 192.168.1.0 netmask 255.255.255.128 {
-  range 192.168.1.26 192.168.1.126;
-  option routers 192.168.1.2;
+subnet 192.168.10.0 netmask 255.255.255.128 {
+  range 192.168.10.26 192.168.10.126;
+  option routers 192.168.10.2;
   option domain-name-servers 147.75.207.207, 147.75.207.208;
 }
 EOF
@@ -150,7 +150,7 @@ Navigate to your Tailscale dashboard, and [create a new Auth key](https://login.
 Copy the key.
 
 Start the Tailscale service with both the auth key and the subnet we used earlier
-to create our VLAN, in my case this was `192.168.1.0/25`:
+to create our VLAN, in my case this was `192.168.10.0/25`:
 
 ```bash
 tailscale up --advertise-routes=<PRIVATE_VLAN_RANGE> --authkey <YOUR_AUTH_KEY>

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -65,7 +65,7 @@ The following will be provisioned:
 The following networking configuration will be applied:
 - All devices will be configured in a Hybrid Bonded mode
 - All devices will have a port connected to a VLAN
-- A DHCP server will assign MicroVM addresses from a private range of `192.168.1.0/25`
+- A DHCP server will assign MicroVM addresses from a private range of `192.168.10.0/25`
 - NAT and filter rules will forward egress traffic from the private interface to the default public one on the host
 - A Tailscale VPN subnet router will route traffic from local VPN-connected devices to MicroVMs
 

--- a/docs/troubleshooting-hosts.md
+++ b/docs/troubleshooting-hosts.md
@@ -133,16 +133,16 @@ Example log output:
 [   14.038692] cloud-init[948]: ci-info: | dummy0 | False |              .               |        .        |   .    | 82:c9:95:a0:b6:a8 |
 [   14.039329] cloud-init[948]: ci-info: |  eth0  |  True |         169.254.0.1          |   255.255.0.0   | global | aa:ff:00:00:00:01 |
 [   14.039954] cloud-init[948]: ci-info: |  eth0  |  True |   fe80::a8ff:ff:fe00:1/64    |        .        |  link  | aa:ff:00:00:00:01 |
-[   14.040572] cloud-init[948]: ci-info: |  eth1  |  True |         192.168.1.92         | 255.255.255.128 | global | 72:bf:3d:dd:7b:f3 |
+[   14.040572] cloud-init[948]: ci-info: |  eth1  |  True |         192.168.10.92         | 255.255.255.128 | global | 72:bf:3d:dd:7b:f3 |
 [   14.041193] cloud-init[948]: ci-info: |  eth1  |  True | fe80::70bf:3dff:fedd:7bf3/64 |        .        |  link  | 72:bf:3d:dd:7b:f3 |
 [   14.041813] cloud-init[948]: ci-info: |   lo   |  True |          127.0.0.1           |    255.0.0.0    |  host  |         .         |
 [   14.042429] cloud-init[948]: ci-info: |   lo   |  True |           ::1/128            |        .        |  host  |         .         |
 [   14.043054] cloud-init[948]: ci-info: +--------+-------+------------------------------+-----------------+--------+-------------------+
 ```
 
-In this case my assigned IP is `192.168.1.92`.
+In this case my assigned IP is `192.168.10.92`.
 
-I can then use my private key to SSH: `ssh -i <private-key> root@192.168.1.92`.
+I can then use my private key to SSH: `ssh -i <private-key> root@192.168.10.92`.
 
 ## My microvm has no internet
 
@@ -157,7 +157,7 @@ If this does not work, check your network interfaces:
 ip a
 ```
 If you do not see the `bond0.1000@bond0` interface, or if it does not have a
-`192.168.1.x` address, go back to the [VLAN](vlan.md) section.
+`192.168.10.x` address, go back to the [VLAN](vlan.md) section.
 
 ## My microvm cannot resolve
 

--- a/docs/vlan.md
+++ b/docs/vlan.md
@@ -37,11 +37,11 @@ ip link add link bond0 name bond0.<VLAN_ID> type vlan id <VLAN_ID>
 
 Add an address from **an internal address block of your choosing** to the
 VLAN **ensuring that you choose a different address within the range for each
-device**. For this I am using `192.168.1.0/25` as I don't need much for the
+device**. For this I am using `192.168.10.0/25` as I don't need much for the
 purposes of this demo.
 ```bash
 ip addr add <IP_ADDRESS> dev bond0.<VLAN_ID>
-# for example: ip addr add 192.168.1.2/25 dev bond0.1000
+# for example: ip addr add 192.168.10.2/25 dev bond0.1000
 ```
 
 Ensure the interface is up:

--- a/terraform/files/byoh.sh
+++ b/terraform/files/byoh.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+sudo apt-get install -y socat ebtables ethtool conntrack
+
+# To do: do we need to add host name to /etc/hosts
+cat /etc/hosts
+
+curl -L https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/releases/download/v0.3.0/byoh-hostagent-linux-amd64 -o ~/byoh-hostagent-linux-amd64
+chmod +x ~/byoh-hostagent-linux-amd64
+
+curl -fsSL https://tailscale.com/install.sh | sh
+
+sudo tailscale up --accept-routes --authkey "$AUTH_KEY"

--- a/terraform/files/dhcp.sh
+++ b/terraform/files/dhcp.sh
@@ -9,9 +9,9 @@ default-lease-time 600;
 max-lease-time 7200;
 authoritative;
 
-subnet 192.168.1.0 netmask 255.255.255.128 {
-  range 192.168.1.26 192.168.1.126;
-  option routers 192.168.1.2;
+subnet 192.168.10.0 netmask 255.255.255.128 {
+  range 192.168.10.26 192.168.10.126;
+  option routers 192.168.10.2;
   option domain-name-servers 147.75.207.207, 147.75.207.208;
 }
 EOF

--- a/terraform/files/tailscale.sh
+++ b/terraform/files/tailscale.sh
@@ -2,4 +2,4 @@
 
 curl -fsSL https://tailscale.com/install.sh | sh
 
-tailscale up --advertise-routes=192.168.1.0/25 --authkey "$AUTH_KEY"
+tailscale up --advertise-routes=192.168.10.0/25 --authkey "$AUTH_KEY"

--- a/terraform/files/vlan.sh
+++ b/terraform/files/vlan.sh
@@ -5,7 +5,7 @@ echo "8021q" >> /etc/modules-load.d/networking.conf
 
 ip link add link bond0 name "bond0.$VLAN_ID" type vlan id "$VLAN_ID"
 
-ip addr add "192.168.1.$ADDR/25" dev "bond0.$VLAN_ID"
+ip addr add "192.168.10.$ADDR/25" dev "bond0.$VLAN_ID"
 
 ip -d link set dev "bond0.$VLAN_ID" up
 


### PR DESCRIPTION
This change add support for the mixed-mode demo by adding a new option to the terraform provisioning in Equinix Metal so that you can create hosts to act as bare metal hosts. These baremetal hosts will have the BYOH agent downloaded to them in preparation of the demo.

I have also also update the docs/terraform/scripts with the following changes:
- Bumped the required terraform version (required by the next item)
- Bumped ubuntu from 20.04 to 22.04
- Changed the CIDR block for the private vlan from 192.168.1.x to 192.168.10.x as 192.168.1.x can clash with a lot of home networks.

Signed-off-by: Richard Case <richard.case@outlook.com>